### PR TITLE
[QLN-40] feat: user now can use otp to reset password

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -95,10 +95,15 @@ public class AuthController : BaseController
 
     [AllowAnonymous]
     [HttpPost("validate-reset-token")]
-    public IActionResult ValidateResetToken(ValidateResetTokenRequest model)
+    public IActionResult VerifyResetPasswordPin(VerifyResetAccountPinRequest model)
     {
-        _accountService.ValidateResetToken(model);
-        return Ok(new { message = "Token is valid" });
+        var requireAccount = _accountService.GetByEmail(model.Email);
+
+        var isVerified = _accountService.ValidateResetToken(model.Pin, requireAccount);
+        var token = _accountService.IssueForgotPasswordToken(requireAccount);
+        return isVerified
+            ? Ok(new { message = "Success", data = new { token } })
+            : BadRequest(new { message = "invalid-pin" });
     }
 
     [AllowAnonymous]

--- a/Models/Accounts/VerifyResetAccountPinRequest.cs
+++ b/Models/Accounts/VerifyResetAccountPinRequest.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace fuquizlearn_api.Models.Accounts;
+
+public class VerifyResetAccountPinRequest
+{
+    [Required] [StringLength(6)] public string Pin { get; set; }
+
+    [Required] [EmailAddress] public string Email { get; set; }
+}

--- a/Services/HelperFrontEnd.cs
+++ b/Services/HelperFrontEnd.cs
@@ -5,8 +5,8 @@ namespace fuquizlearn_api.Services;
 
 public interface IHelperFrontEnd
 {
-    public string getBaseUrl();
-    public string getUrl(string uri);
+    public string GetBaseUrl();
+    public string GetUrl(string uri);
 }
 
 public class HelperFrontEnd : IHelperFrontEnd
@@ -20,12 +20,12 @@ public class HelperFrontEnd : IHelperFrontEnd
         _baseUrl = _settings.FrontEndUrl;
     }
 
-    public string getBaseUrl()
+    public string GetBaseUrl()
     {
         return _baseUrl;
     }
 
-    public string getUrl(string uri)
+    public string GetUrl(string uri)
     {
         if (uri.StartsWith('/') && _baseUrl.EndsWith('/')) return _baseUrl + uri.PadLeft(1);
 


### PR DESCRIPTION
# Test
## Successfully reset password use OTP
1. Hit `auth/forgot-passwod` to get OTP
2. Copy OTP from email
3. Get token at at `auth/validate-reset-token`
4. change password at `auth/reset-password`

Expected:
- Successfully change password

## Bad request when provide incorrect OTP
1. Hit `auth/forgot-passwod` to get OTP
2. Copy OTP from email
3. Get token at OTP at `auth/validate-reset-token`
4. Fill incorrect OTP

Expected:
- throw `invalid-pin` message
- No data.token provided